### PR TITLE
Fix deprecation warnings and correct state_class usage

### DIFF
--- a/custom_components/multical_21/__init__.py
+++ b/custom_components/multical_21/__init__.py
@@ -76,8 +76,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
-            await hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setups(entry, [platform])
             )
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/multical_21/sensor.py
+++ b/custom_components/multical_21/sensor.py
@@ -29,20 +29,20 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         name="V1Reverse",
 	icon="mdi:water-sync",
         device_class=SensorDeviceClass.WATER,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="74",  # 0x004a
         name="Flow",
 	icon="mdi:waves",
         device_class=SensorDeviceClass.WATER,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=None,
     ),
     SensorEntityDescription(
         key="1004",  # 0x03ec
         name="HoursCounter",
 	icon="mdi:clock",
-        device_class=SensorDeviceClass.WATER,
+        device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
@@ -50,8 +50,8 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
         key="99",  # 0x0063
         name="Info",
 	icon="mdi:information",
-        device_class=SensorDeviceClass.WATER,
-        state_class=SensorStateClass.MEASUREMENT,
+        device_class=None,
+        state_class=None,
         entity_registry_enabled_default=False,
     ),
 ]


### PR DESCRIPTION
1) Replaced deprecated async_forward_entry_setup with async_forward_entry_setups.
2) Corrected state_class for sensors to align with water device class requirements.