### PR TITLE
Modernize integration structure (v2.2.0)

### DIFF
--- a/custom_components/multical_21/__init__.py
+++ b/custom_components/multical_21/__init__.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT
+from homeassistant.const import CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -21,25 +21,22 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     DOMAIN,
+    MANUFACTURER,
+    MODEL,
     NAME,
-    PLATFORMS,
     VERSION,
 )
 from .pykamstrup.kamstrup import Kamstrup
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
-async def async_setup(_hass: HomeAssistant, _config: dict) -> bool:
-    """Set up this integration using YAML is not supported."""
-    return True
+KamstrupConfigEntry = ConfigEntry["KamstrupUpdateCoordinator"]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: KamstrupConfigEntry) -> bool:
     """Set up this integration using UI."""
-    if hass.data.get(DOMAIN) is None:
-        hass.data.setdefault(DOMAIN, {})
-
     port = entry.data.get(CONF_PORT)
     scan_interval_seconds = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     scan_interval = timedelta(seconds=scan_interval_seconds)
@@ -62,9 +59,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_info = DeviceInfo(
         entry_type=DeviceEntryType.SERVICE,
         identifiers={(DOMAIN, port)},
-        manufacturer=NAME,
+        manufacturer=MANUFACTURER,
+        model=MODEL,
         name=NAME,
-        model=VERSION,
+        sw_version=VERSION,
     )
 
     coordinator = KamstrupUpdateCoordinator(
@@ -75,27 +73,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_info=device_info,
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     await coordinator.async_config_entry_first_refresh()
 
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: KamstrupConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        coordinator = hass.data[DOMAIN].pop(entry.entry_id)
-        await coordinator.async_close()
+        await entry.runtime_data.async_close()
 
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload a config entry."""
+async def async_reload_entry(hass: HomeAssistant, entry: KamstrupConfigEntry) -> None:
+    """Reload a config entry when its options change."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -135,9 +134,9 @@ class KamstrupUpdateCoordinator(DataUpdateCoordinator):
         self._commands.remove(command)
 
     async def async_close(self) -> None:
-        """Close resources."""
+        """Close the serial connection to the meter."""
         _LOGGER.debug("Closing Kamstrup connection")
-        self.kamstrup = None
+        await self.hass.async_add_executor_job(self.kamstrup.close)
 
     async def _async_update_data(self) -> dict[int, Any]:
         """Update data via library."""

--- a/custom_components/multical_21/config_flow.py
+++ b/custom_components/multical_21/config_flow.py
@@ -1,5 +1,14 @@
 """Adds config flow for multical 21."""
-from homeassistant import config_entries
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_PORT, CONF_SCAN_INTERVAL, CONF_TIMEOUT
 from homeassistant.core import callback
 import serial
@@ -14,78 +23,66 @@ def _test_serial_port(port: str, baudrate: int, timeout: float) -> None:
     s.close()
 
 
-class KamstrupFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+class KamstrupFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for multical 21."""
 
     VERSION = 1
 
-    def __init__(self):
-        """Initialize."""
-        self._errors = {}
-
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        self._errors = {}
-
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            if user_input[CONF_PORT] is not None:
-                try:
-                    await self.hass.async_add_executor_job(
-                        _test_serial_port,
-                        user_input[CONF_PORT],
-                        DEFAULT_BAUDRATE,
-                        DEFAULT_TIMEOUT,
-                    )
-
-                    return self.async_create_entry(
-                        title=user_input[CONF_PORT], data=user_input
-                    )
-                except serial.SerialException:
-                    self._errors["base"] = "port"
+            try:
+                await self.hass.async_add_executor_job(
+                    _test_serial_port,
+                    user_input[CONF_PORT],
+                    DEFAULT_BAUDRATE,
+                    DEFAULT_TIMEOUT,
+                )
+            except serial.SerialException:
+                errors["base"] = "port"
             else:
-                self._errors["base"] = "port"
+                return self.async_create_entry(
+                    title=user_input[CONF_PORT], data=user_input
+                )
 
-            return await self._show_config_form(user_input)
-
-        user_input = {}
-        user_input[CONF_PORT] = ""
-
-        return await self._show_config_form(user_input)
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        return KamstrupOptionsFlowHandler()
-
-    async def _show_config_form(self, user_input):
-        """Show the configuration form to edit location data."""
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_PORT, default=user_input[CONF_PORT]): str,
+                    vol.Required(
+                        CONF_PORT, default=(user_input or {}).get(CONF_PORT, "")
+                    ): str,
                 }
             ),
-            errors=self._errors,
+            errors=errors,
         )
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> KamstrupOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return KamstrupOptionsFlowHandler()
 
-class KamstrupOptionsFlowHandler(config_entries.OptionsFlow):
+
+class KamstrupOptionsFlowHandler(OptionsFlow):
     """Kamstrup config flow options handler."""
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Manage the options."""
         return await self.async_step_user()
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
         if user_input is not None:
-            return self.async_create_entry(
-                title=self.config_entry.data.get(CONF_PORT), data=user_input
-            )
+            return self.async_create_entry(data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/multical_21/const.py
+++ b/custom_components/multical_21/const.py
@@ -5,17 +5,12 @@ from typing import Final
 # Base component constants
 NAME: Final = "multical 21"
 DOMAIN: Final = "multical_21"
-VERSION: Final = "2.1.3"
-MODEL: Final = "382"
+VERSION: Final = "2.2.0"
+MODEL: Final = "Multical 21"
 MANUFACTURER: Final = "Kamstrup"
-ATTRIBUTION: Final = "Data provided by multical 21 meter"
 
 # Defaults
 DEFAULT_NAME: Final = NAME
 DEFAULT_BAUDRATE: Final = 1200
 DEFAULT_SCAN_INTERVAL: Final = 60
 DEFAULT_TIMEOUT: Final = 1.0
-
-# Platforms
-SENSOR: Final = "sensor"
-PLATFORMS: Final = [SENSOR]

--- a/custom_components/multical_21/diagnostics.py
+++ b/custom_components/multical_21/diagnostics.py
@@ -1,16 +1,15 @@
 """Diagnostics support for multical_21."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import DOMAIN, KamstrupUpdateCoordinator
+from . import KamstrupConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: KamstrupConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
-    coordinator: KamstrupUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     return {
         "config_entry": config_entry.as_dict(),

--- a/custom_components/multical_21/manifest.json
+++ b/custom_components/multical_21/manifest.json
@@ -1,11 +1,13 @@
 {
   "domain": "multical_21",
   "name": "multical 21",
-  "documentation": "https://github.com/kristianschneider/ha-multical_21//blob/main/README.md",
-  "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/kristianschneider/ha-multical_21//issues",
-  "version": "2.1.3",
-  "config_flow": true,
   "codeowners": ["@kristianschneider"],
-  "requirements": ["pyserial==3.5"]
+  "config_flow": true,
+  "documentation": "https://github.com/kristianschneider/ha-multical_21/blob/main/README.md",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/kristianschneider/ha-multical_21/issues",
+  "requirements": ["pyserial==3.5"],
+  "single_config_entry": true,
+  "version": "2.2.0"
 }

--- a/custom_components/multical_21/pykamstrup/kamstrup.py
+++ b/custom_components/multical_21/pykamstrup/kamstrup.py
@@ -24,6 +24,10 @@ class Kamstrup:
         """Initialize"""
         self.ser = serial.Serial(port=serial_port, baudrate=baudrate, timeout=timeout)
 
+    def close(self) -> None:
+        """Close the serial port."""
+        self.ser.close()
+
     @classmethod
     def _crc_1021(cls, message: tuple[int]) -> int:
         """Kamstrup uses the "true" CCITT CRC-16"""

--- a/custom_components/multical_21/sensor.py
+++ b/custom_components/multical_21/sensor.py
@@ -1,22 +1,18 @@
-"""Sensor platform for kamstrup_382."""
+"""Sensor platform for multical_21."""
 
 from homeassistant.components.sensor import (
-    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
 
-from . import KamstrupUpdateCoordinator
-from .const import DEFAULT_NAME, DOMAIN
+from . import KamstrupConfigEntry, KamstrupUpdateCoordinator
+from .const import DEFAULT_NAME
 
 DESCRIPTIONS: list[SensorEntityDescription] = [
     SensorEntityDescription(
@@ -61,29 +57,26 @@ DESCRIPTIONS: list[SensorEntityDescription] = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: KamstrupConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Kamstrup sensors based on a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
-    entities: list[KamstrupSensor] = []
-
-    # Add all meter sensors described above.
-    for description in DESCRIPTIONS:
-        entities.append(
-            KamstrupMeterSensor(
-                coordinator=coordinator,
-                entry_id=entry.entry_id,
-                description=description,
-            )
+    async_add_entities(
+        KamstrupMeterSensor(
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            description=description,
         )
-
-    async_add_entities(entities)
+        for description in DESCRIPTIONS
+    )
 
 
 class KamstrupSensor(CoordinatorEntity[KamstrupUpdateCoordinator], SensorEntity):
     """Defines a Kamstrup sensor."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -94,9 +87,10 @@ class KamstrupSensor(CoordinatorEntity[KamstrupUpdateCoordinator], SensorEntity)
         """Initialize Kamstrup sensor."""
         super().__init__(coordinator=coordinator)
 
-        self.entity_id = f"{SENSOR_DOMAIN}.{slugify(f'{DEFAULT_NAME}_{description.name}')}"
         self.entity_description = description
-        self._attr_unique_id = f"{entry_id}-{DEFAULT_NAME} {self.name}"
+        # The unique_id format is kept identical to previous releases so
+        # existing registry entries (and their entity_ids) are preserved.
+        self._attr_unique_id = f"{entry_id}-{DEFAULT_NAME} {description.name}"
         self._attr_device_info = coordinator.device_info
 
 

--- a/custom_components/multical_21/translations/en.json
+++ b/custom_components/multical_21/translations/en.json
@@ -11,9 +11,6 @@
     },
     "error": {
       "port": "Can't connect to given serial port."
-    },
-    "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
     }
   },
   "options": {

--- a/custom_components/multical_21/translations/nl.json
+++ b/custom_components/multical_21/translations/nl.json
@@ -11,9 +11,6 @@
     },
     "error": {
       "port": "Kan geen verbinding maken met de opgegeven poort."
-    },
-    "abort": {
-      "single_instance_allowed": "Slechts één instantie is toegestaan."
     }
   },
   "options": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Multical 21",
-  "homeassistant": "2022.11.0",
+  "homeassistant": "2024.11.0",
   "render_readme": true
 }


### PR DESCRIPTION
Stacked on #5 — merge that first; GitHub will retarget this PR to `main` automatically.

## Changes

- **`entry.runtime_data`** replaces all `hass.data[DOMAIN]` bookkeeping (typed via `KamstrupConfigEntry` alias)
- **Serial port actually closed on unload** — new `Kamstrup.close()`, called via the executor. Previously `async_close()` only dropped the reference, leaking the open port
- **Options changes apply immediately** — the `async_reload_entry` listener existed but was never registered, so scan-interval/timeout changes silently required a restart
- **manifest**: `single_config_entry: true` (replaces the manual `_async_current_entries()` abort and its translations), `integration_type: "device"`, fixed `//` in URLs
- **Sensors**: `has_entity_name`, manual `entity_id` assignment dropped — the registry preserves existing entity IDs and the unique_id format is byte-for-byte unchanged, so **no entities are renamed or duplicated**
- **DeviceInfo**: manufacturer `Kamstrup`, model `Multical 21`, `sw_version` (was manufacturer "multical 21", model = version string)
- **Config flow**: `ConfigFlowResult` type hints; options flow no longer sets a title
- Removed the empty `async_setup`, unused constants (`MODEL "382"` fork leftover, `ATTRIBUTION`, string `PLATFORMS`); `PLATFORMS` now uses the `Platform` enum
- `hacs.json`: minimum HA 2024.11.0 (needed for `runtime_data` + auto-set `OptionsFlow.config_entry`)

## Validation

Deployed live on HA OS / Core 2026.7.3 (Raspberry Pi 4, Multical 21 via IR eye):

- Config entry reaches `loaded`; journal clean apart from the standard custom-integration notice
- Entity registry after restart: same 5 entities, identical `entity_id`s and `unique_id`s, no `_2` duplicates, disabled-by-default entities unchanged
- `sensor.multical_21_v1` advancing; Flow reporting in `L/h` / `volume_flow_rate`
- Friendly names now compose as "multical 21 V1" etc. via `has_entity_name`

Note for dashboards: entity IDs are unchanged, but displayed friendly names gain the device-name prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)